### PR TITLE
dev(hansbug): add support for Python3.12 and PyPy3.10, drop support for Python3.7

### DIFF
--- a/.github/workflows/badge.yml
+++ b/.github/workflows/badge.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7 ]
+        python-version: [ 3.8 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7 ]
+        python-version: [ 3.8 ]
 
     services:
       plantuml:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,11 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
           - 'pypy-3.7'
           - 'pypy-3.8'
           - 'pypy-3.9'
+          - 'pypy-3.10'
 
     steps:
       - name: Get system version for Linux

--- a/docs/source/tutorials/installation/index.rst
+++ b/docs/source/tutorials/installation/index.rst
@@ -1,7 +1,7 @@
 Installation
 ===================
 
-``HBUtils`` is currently hosted on PyPI. It required python >= 3.7.
+``HBUtils`` is currently hosted on PyPI. It required python >= 3.8.
 
 You can simply install HBUtils from PyPI with the following command:
 

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     url='https://github.com/hansbug/hbutils',
 
     # environment
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=requirements,
     tests_require=group_requirements['test'],
     extras_require=group_requirements,
@@ -56,7 +56,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
* [x] Run unittest for Python3.12
* [x] Run unittest for PyPy3.10 (failed because numpy do not have pypy3.10 version, and it build failed on windows and macos)